### PR TITLE
include only relative library pathname in .mpy file

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -96,8 +96,10 @@ def library(library_path, output_directory, mpy_cross=None):
         output_file = os.path.join(output_directory,
                                    filename.replace(".py", new_extension))
         if mpy_cross:
+
             mpy_success = subprocess.call([mpy_cross,
                                            "-o", output_file,
+                                           "-s", filename,
                                            full_path])
             if mpy_success != 0:
                 raise RuntimeError("mpy-cross failed on", full_path)
@@ -116,6 +118,7 @@ def library(library_path, output_directory, mpy_cross=None):
                                        filename.replace(".py", new_extension))
             mpy_success = subprocess.call([mpy_cross,
                                            "-o", output_file,
+                                           "-s", filename,
                                            full_path])
             if mpy_success != 0:
                 raise RuntimeError("mpy-cross failed on", full_path)


### PR DESCRIPTION
When doing "mpy-cross", give a filename relative to the top of the library, so that long irrelevant build paths will not be included in the .mpy files and won't show up in backtraces.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "adafruit_lis3dh/lis3dh.py", line 210, in __init__
```
instead of 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "home/travis/build/adafruit/Adafruit_CircuitPython_Bundle/libraries/helpers/adafruit_lis3dh/lis3dh.py", line 210, in __init__
```

This was a bit hard to test due to a lot of manual setup for bundle building, but it seems to be work.

Fixes #1

