### PR TITLE
Add support for replacing placeholder version string with git tag

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -118,14 +118,7 @@ def _find_libraries(current_path, depth):
 def build_bundles(filename_prefix, output_directory, library_location, library_depth):
     os.makedirs(output_directory, exist_ok=True)
 
-    bundle_version = None
-    tag = subprocess.run('git describe --tags --exact-match', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if tag.returncode == 0:
-        bundle_version = tag
-    else:
-        commitish = subprocess.run("git log --pretty=format:'%h' -n 1", shell=True, stdout=subprocess.PIPE)
-        bundle_version = commitish
-    bundle_version = bundle_version.stdout.strip().decode("utf-8", "strict")
+    bundle_version = build.version_string()
 
     libs = _find_libraries(os.path.abspath(library_location), library_depth)
     print(libs)
@@ -156,7 +149,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
             mpy_cross = "build_deps/mpy-cross-" + version["name"]
             build.mpy_cross(mpy_cross, version["tag"])
         zip_filename = os.path.join(output_directory,
-            filename_prefix + '-{TAG}-{VERSION}.zip'.format(
+            filename_prefix + '-{TAG}-mpy-{VERSION}.zip'.format(
                 TAG=version["name"],
                 VERSION=bundle_version))
         build_bundle(libs, bundle_version, zip_filename, mpy_cross=mpy_cross,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Click
+semver

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='circuitpython-build-tools',
       package_data={'circuitpython_build_tools': ['data/mpy-cross-*']},
       zip_safe=False,
       python_requires='>=3.4',
-      install_requires=['Click'],
+      install_requires=['Click', 'semver'],
       entry_points='''
         [console_scripts]
         circuitpython-build-bundles=circuitpython_build_tools.scripts.build_bundles:build_bundles


### PR DESCRIPTION
based versions that are semver compatible. If a prerelease
identifier is already present we'll bump ahead by adding `.plus.`
and the number of subsequent commits. If its not, we'll bump the
patch digit and call it `alpha.0` and add the remaining `.plus.` bit.

This also changes the file names of the mpy zips to include "-mpy-"
which should help space out two potentially confusing version strings
(that of circuitpython and that of the library.)