### PR TITLE
Raise an error when multiple top-level py files exist.

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -101,12 +101,8 @@ def library(library_path, output_directory, mpy_cross=None):
             py_files.append(filename)
 
     if len(py_files) > 1:
-        output_directory = os.path.join(output_directory, library)
-        os.makedirs(output_directory)
-        package_init = os.path.join(output_directory, "__init__.py")
-        # Touch the __init__ file.
-        with open(package_init, 'a'):
-            pass
+        raise ValueError("Multiple top level py files not allowed. Please put them in a package "
+                         "or combine them into a single file.")
 
     if len(package_files) > 1:
         for fn in package_files:
@@ -120,7 +116,12 @@ def library(library_path, output_directory, mpy_cross=None):
     if mpy_cross:
         new_extension = ".mpy"
 
-    library_version = version_string(library_path, valid_semver=True)
+    try:
+        library_version = version_string(library_path, valid_semver=True)
+    except ValueError as e:
+        print(library_path + " has version that doesn't follow SemVer (semver.org)")
+        print(e)
+        library_version = version_string(library_path)
 
     for filename in py_files:
         full_path = os.path.join(library_path, filename)

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -62,8 +62,15 @@ def build_bundle(libs, bundle_version, output_filename,
     success = True
     total_size = 512
     for library_path in libs:
-        build.library(library_path, build_lib_dir, mpy_cross=mpy_cross)
+        try:
+            build.library(library_path, build_lib_dir, mpy_cross=mpy_cross)
+        except ValueError as e:
+            print(library_path)
+            print(e)
+            success = False
 
+    print()
+    print("Generating VERSIONS")
     if multiple_libs:
         with open(os.path.join(build_lib_dir, "VERSIONS.txt"), "w") as f:
             f.write(bundle_version + "\r\n")
@@ -78,6 +85,9 @@ def build_bundle(libs, bundle_version, output_filename,
                     repo = line.strip()[:-len(".git")]
                 else:
                     f.write(repo.decode("utf-8", "strict") + "/releases/tag/" + line.strip().decode("utf-8", "strict") + "\r\n")
+
+    print()
+    print("Zipping")
 
     with zipfile.ZipFile(output_filename, 'w') as bundle:
         build_metadata = {"build-tools-version": build_tools_version}


### PR DESCRIPTION
We used to attempt to create a package for the files but this will
change the import behavior only when bundled. Instead, the error
prompts the library author to fix it by combining the files or
creating a package.