### PR TITLE
Fix common case.

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -41,7 +41,7 @@ def version_string(path=None, *, valid_semver=False):
         describe = subprocess.run("git describe --tags --always", shell=True, stdout=subprocess.PIPE, cwd=path)
         describe = describe.stdout.strip().decode("utf-8", "strict").rsplit("-", maxsplit=2)
         if len(describe) == 3:
-            tag, additional_commits, commitish = describe.stdout.strip().decode("utf-8", "strict").rsplit("-", maxsplit=2)
+            tag, additional_commits, commitish = describe
             commitish = commitish[1:]
         else:
             tag = "0.0.0"


### PR DESCRIPTION
This fixes a crash with:
```
0.23s$ circuitpython-build-bundles --filename_prefix circuitpython-community-bundle --library_location libraries --library_depth 2
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/bin/circuitpython-build-bundles", line 11, in <module>
    sys.exit(build_bundles())
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/circuitpython_build_tools/scripts/build_bundles.py", line 131, in build_bundles
    bundle_version = build.version_string()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/circuitpython_build_tools/build.py", line 44, in version_string
    tag, additional_commits, commitish = describe.stdout.strip().decode("utf-8", "strict").rsplit("-", maxsplit=2)
AttributeError: 'list' object has no attribute 'stdout'
```

[Here](https://travis-ci.org/adafruit/CircuitPython_Community_Bundle/jobs/321888177) is an example.