### PR TITLE
Reenable 2.x bundle

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -25,6 +25,7 @@
 # The tag specifies which version of CircuitPython to use for mpy-cross.
 # The name is used when constructing the zip file names.
 VERSIONS = [
+    {"tag": "2.3.1", "name": "2.x"},
     {"tag": "3.0.0", "name": "3.x"},
     {"tag": "4.0.0-alpha.2", "name": "4.x"},
 ]


### PR DESCRIPTION
We're reenabling the 2.x bundle until we've made it clear through guide updates etc that we're deprecating it.