### PR TITLE
Rename Folder In Zip

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -109,9 +109,9 @@ def build_bundle(libs, bundle_version, output_filename,
         bundle.comment = json.dumps(build_metadata).encode("utf-8")
         if multiple_libs:
             readme_zip_dir = build_dir.replace(".zip", "")
-            total_size += add_file(bundle, "README.txt", os.path.join(readme_zip_dir.replace("-", "_"), "README.txt"))
+            total_size += add_file(bundle, "README.txt", os.path.join(readme_zip_dir, "README.txt"))
         for root, dirs, files in os.walk(build_dir):
-            ziproot = root[len(build_dir + "/"):].replace("-", "_")
+            ziproot = root[len(build_dir + "/"):]
             for filename in files:
                 total_size += add_file(bundle, os.path.join(root, filename),
                                        os.path.join(ziproot, filename.replace("-", "_")))


### PR DESCRIPTION
Fixes [Adafruit_CircuitPython_Bundle #105](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/105)

```
~/Dev/local-bundles$ unzip -l local-test-py-4b060c0.zip
Archive:  local-test-py-4b060c0.zip
{"build-tools-version": "devel"}
  Length      Date    Time    Name
---------  ---------- -----   ----
      117  2018-10-13 09:09   build-local-test-py-4b060c0/README.txt
     8314  2018-11-10 10:05   build-local-test-py-4b060c0/VERSIONS.txt
    17681  2018-11-10 10:05   build-local-test-py-4b060c0/lib/adafruit_ina219.py
    10435  2018-11-10 10:05   build-local-test-py-4b060c0/lib/adafruit_dht.py
     9485  2018-11-10 10:05   build-local-test-py-4b060c0/lib/adafruit_ssd1306.py
```