### PR TITLE
Simplify parsing git output in build_bundle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ circuitpython-build-tools package.
 ```shell
 python3 -m venv .env
 source .env/bin/activate
-pip install wheel
 pip install circuitpython-build-tools
 circuitpython-build-bundles --filename_prefix <output file prefix> --library_location .
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ circuitpython-build-tools package.
 ```shell
 python3 -m venv .env
 source .env/bin/activate
+pip install wheel
 pip install circuitpython-build-tools
 circuitpython-build-bundles --filename_prefix <output file prefix> --library_location .
 ```

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -81,7 +81,7 @@ def build_bundle(libs, bundle_version, output_filename,
     if multiple_libs:
         with open(os.path.join(build_dir, top_folder, "VERSIONS.txt"), "w") as f:
             f.write(bundle_version + "\r\n")
-            versions = subprocess.run('git submodule foreach \"git remote get-url origin && git describe --tags\"', shell=True, stdout=subprocess.PIPE, cwd=os.path.commonpath(libs))
+            versions = subprocess.run('git submodule --quiet foreach --quiet \"git remote get-url origin && git describe --tags\"', shell=True, stdout=subprocess.PIPE, cwd=os.path.commonpath(libs))
             if versions.returncode != 0:
                 print("Failed to generate versions file. Its likely a library hasn't been "
                       "released yet.")
@@ -89,7 +89,7 @@ def build_bundle(libs, bundle_version, output_filename,
 
             repo = None
             for line in versions.stdout.split(b"\n"):
-                if line.startswith(b"Entering") or not line:
+                if not line:
                     continue
                 if line.startswith(b"git@"):
                     repo = b"https://github.com/" + line.split(b":")[1][:-len(".git")]

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -81,7 +81,7 @@ def build_bundle(libs, bundle_version, output_filename,
     if multiple_libs:
         with open(os.path.join(build_dir, top_folder, "VERSIONS.txt"), "w") as f:
             f.write(bundle_version + "\r\n")
-            versions = subprocess.run('git submodule --quiet foreach --quiet \"git remote get-url origin && git describe --tags\"', shell=True, stdout=subprocess.PIPE, cwd=os.path.commonpath(libs))
+            versions = subprocess.run('git submodule --quiet foreach \"git remote get-url origin && git describe --tags\"', shell=True, stdout=subprocess.PIPE, cwd=os.path.commonpath(libs))
             if versions.returncode != 0:
                 print("Failed to generate versions file. Its likely a library hasn't been "
                       "released yet.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Click
 semver
+wheel


### PR DESCRIPTION
Fixes #25 by suppressing the printing of "Entering ..." or something else in another language.