### PR TITLE
Add Test Matrix For Pull Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 circuitpython_build_tools/data/
 .eggs
 version.py
+.env/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-sudo: false
-dist: trusty
+dist: xenial
 language: python
 python:
 - '3.6'
-script:
-- python3 -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
 
+before_deploy:
+  script:
+    - python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
 
 deploy:
   provider: pypi
@@ -15,3 +15,31 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+
+matrix:
+  include:
+    - python: "3.6"
+      name: "Test CircuitPython Bundle"
+      if: type = pull_request
+      script:
+        - echo "Building mpy-cross" && echo "travis_fold:start:mpy-cross"
+        - python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
+        - echo "travis_fold:end:mpy-cross"
+        - pip install -e .
+        - echo "Cloning Adafruit_CircuitPython_Bundle" && echo "travis_fold:start:clone"
+        - git clone --recurse-submodules https://github.com/adafruit/Adafruit_CircuitPython_Bundle.git
+        - echo "travis_fold:end:clone"
+        - cd Adafruit_CircuitPython_Bundle
+        - circuitpython-build-bundles --filename_prefix test-bundle --library_location libraries --library_depth 2
+
+    - python: "3.6"
+      name: "Test Single Library Bundle"
+      if: type = pull_request
+      script:
+        - echo "Building mpy-cross" && echo "travis_fold:start:mpy-cross"
+        - python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
+        - echo "travis_fold:end:mpy-cross"
+        - pip install -e .
+        - git clone https://github.com/adafruit/Adafruit_CircuitPython_FeatherWing.git
+        - cd Adafruit_CircuitPython_FeatherWing
+        - circuitpython-build-bundles --filename_prefix test-single --library_location .

--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ source .env/bin/activate
 pip install circuitpython-build-tools
 circuitpython-build-bundles --filename_prefix <output file prefix> --library_location .
 ```
+
+When making changes to `circuitpython-build-tools` itself, you can test your changes
+locally like so:
+
+```shell
+cd circuitpython-build-tools # this will be specific to your storage location
+python3 -m venv .env
+source .env/bin/activate
+pip install -e .  # '-e' is pip's "development" install feature
+circuitpython-build-bundles --filename_prefix <output file prefix> --library_location <library location>
+```
+
+## Contributing
+
+Contributions are welcome! Please read our [Code of Conduct]
+(https://github.com/adafruit/Adafruit_CircuitPython_adabot/blob/master/CODE_OF_CONDUCT.md)
+before contributing to help this project stay welcoming.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ locally like so:
 cd circuitpython-build-tools # this will be specific to your storage location
 python3 -m venv .env
 source .env/bin/activate
+python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
 pip install -e .  # '-e' is pip's "development" install feature
 circuitpython-build-bundles --filename_prefix <output file prefix> --library_location <library location>
 ```


### PR DESCRIPTION
After my breaking fiasco a couple days ago, I thought it would be a good idea to implement some tests before PRs are merged. Due to my own lack of knowledge on a good way to test changes without `pip`, some bugs weren't apparent until the changes were deployed to PyPI.

So, I began to look into how to both improve my local testing, and also apply it to CI. Turns out, pip has a "development" install flag, `-e`, which will install based on a VCS repo. (_My previous method was to hack in a `if __name__ == "__main__"`; not a good method, clearly._)

I set this up as a matrix for now. One matrix runs a test on the entire CircuitPython Library Bundle, and the other runs a test on a single library (FeatherWing). A downside to using a matrix is that each VM has to build its own `mpy-cross` versions, but it the runs are only taking about 5 minutes total.

Also, the matrix scripts will only appear if the Travis job type is `pull_request`. Straight commits will result in absolutely nothing, as the request is "cancelled":
![cpy_build_tools_travis_requests](https://user-images.githubusercontent.com/21211479/57412344-0564f600-71b6-11e9-9a58-b147de8c2b1a.png)

Example runs can be seen here: https://travis-ci.com/sommersoft/circuitpython-build-tools/builds

Lastly, I added some verbiage to the README about testing local changes and a link to the CoC for contributing.