### PR TITLE
Attempt 2: Include mpy-cross '__init__.py' In Packages; Restructure Package Bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ locally like so:
 cd circuitpython-build-tools # this will be specific to your storage location
 python3 -m venv .env
 source .env/bin/activate
-python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/
 pip install -e .  # '-e' is pip's "development" install feature
 circuitpython-build-bundles --filename_prefix <output file prefix> --library_location <library location>
 ```

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -100,7 +100,7 @@ def _munge_to_temp(original_path, temp_file, library_version):
                 temp_file.write(line.encode("utf-8") + b"\r\n")
     temp_file.flush()
 
-def library(library_path, output_directory, mpy_cross=None, example_bundle=False, pkg_folder_prefix=None):
+def library(library_path, output_directory, pkg_folder_prefix, mpy_cross=None, example_bundle=False):
     py_files = []
     package_files = []
     example_files = []
@@ -115,7 +115,10 @@ def library(library_path, output_directory, mpy_cross=None, example_bundle=False
             # 'walked_files' while retaining subdirectory structure
             walked_files = []
             for path in path_walk:
-                path_tail_idx = path[0].rfind("/") + 1
+                if filename.startswith("examples"):
+                    path_tail_idx = path[0].rfind("examples/") + 9
+                else:
+                    path_tail_idx = path[0].rfind("/") + 1
                 path_tail = path[0][path_tail_idx:]
                 rel_path = ""
                 # if this entry is the package top dir, keep it
@@ -134,11 +137,10 @@ def library(library_path, output_directory, mpy_cross=None, example_bundle=False
                 example_files.extend(files)
                 #print("- example files: {}".format(example_files))
             else:
-                if pkg_folder_prefix:
-                    if (not example_bundle and
-                        not filename.startswith(pkg_folder_prefix)):
-                            #print("skipped path: {}".format(full_path))
-                            continue
+                if (not example_bundle and
+                    not filename.startswith(pkg_folder_prefix)):
+                        #print("skipped path: {}".format(full_path))
+                        continue
                 if not example_bundle:
                     package_files.extend(files)
                     #print("- package files: {} | {}".format(filename, package_files))

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -100,7 +100,7 @@ def _munge_to_temp(original_path, temp_file, library_version):
                 temp_file.write(line.encode("utf-8") + b"\r\n")
     temp_file.flush()
 
-def library(library_path, output_directory, pkg_folder_prefix, mpy_cross=None, example_bundle=False):
+def library(library_path, output_directory, package_folder_prefix, mpy_cross=None, example_bundle=False):
     py_files = []
     package_files = []
     example_files = []
@@ -138,7 +138,7 @@ def library(library_path, output_directory, pkg_folder_prefix, mpy_cross=None, e
                 #print("- example files: {}".format(example_files))
             else:
                 if (not example_bundle and
-                    not filename.startswith(pkg_folder_prefix)):
+                    not filename.startswith(package_folder_prefix)):
                         #print("skipped path: {}".format(full_path))
                         continue
                 if not example_bundle:

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -160,7 +160,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
         filename_prefix + '-py-{VERSION}.zip'.format(
             VERSION=bundle_version))
     build_bundle(libs, bundle_version, zip_filename,
-                 pkg_folder_prefix=pkg_folder_prefix,
+                 pkg_folder_prefix=package_folder_prefix,
                  build_tools_version=build_tools_version)
 
     # Build .mpy bundle(s)
@@ -179,7 +179,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
                 VERSION=bundle_version))
         build_bundle(libs, bundle_version, zip_filename, mpy_cross=mpy_cross,
                      build_tools_version=build_tools_version,
-                     pkg_folder_prefix=pkg_folder_prefix)
+                     pkg_folder_prefix=package_folder_prefix)
 
     # Build example bundle
     zip_filename = os.path.join(output_directory,

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -136,7 +136,7 @@ def _find_libraries(current_path, depth):
 @click.option('--output_directory', default="bundles", help="Output location for the zip files.")
 @click.option('--library_location', required=True, help="Location of libraries to bundle.")
 @click.option('--library_depth', default=0, help="Depth of library folders. This is useful when multiple libraries are bundled together but are initially in separate subfolders.")
-@click.option('--package_folder_prefix', default=None, required=False, help="Prefix string used to determine package folders to bundle.")
+@click.option('--package_folder_prefix', default="adafruit_", help="Prefix string used to determine package folders to bundle.")
 def build_bundles(filename_prefix, output_directory, library_location, library_depth, package_folder_prefix):
     os.makedirs(output_directory, exist_ok=True)
 

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -48,9 +48,8 @@ def add_file(bundle, src_file, zip_name):
     return file_sector_size
 
 
-def build_bundle(libs, bundle_version, output_filename,
-        build_tools_version="devel", mpy_cross=None, example_bundle=False,
-        pkg_folder_prefix=None):
+def build_bundle(libs, bundle_version, output_filename, pkg_folder_prefix,
+        build_tools_version="devel", mpy_cross=None, example_bundle=False):
     build_dir = "build-" + os.path.basename(output_filename)
     top_folder = os.path.basename(output_filename).replace(".zip", "")
     build_lib_dir = os.path.join(build_dir, top_folder, "lib")
@@ -70,7 +69,7 @@ def build_bundle(libs, bundle_version, output_filename,
     success = True
     for library_path in libs:
         try:
-            build.library(library_path, build_lib_dir,  pkg_folder_prefix=pkg_folder_prefix,
+            build.library(library_path, build_lib_dir,  pkg_folder_prefix,
                           mpy_cross=mpy_cross, example_bundle=example_bundle)
         except ValueError as e:
             print("build.library failure:", library_path)
@@ -159,8 +158,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
     zip_filename = os.path.join(output_directory,
         filename_prefix + '-py-{VERSION}.zip'.format(
             VERSION=bundle_version))
-    build_bundle(libs, bundle_version, zip_filename,
-                 pkg_folder_prefix=package_folder_prefix,
+    build_bundle(libs, bundle_version, zip_filename, package_folder_prefix,
                  build_tools_version=build_tools_version)
 
     # Build .mpy bundle(s)
@@ -177,13 +175,12 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
             filename_prefix + '-{TAG}-mpy-{VERSION}.zip'.format(
                 TAG=version["name"],
                 VERSION=bundle_version))
-        build_bundle(libs, bundle_version, zip_filename, mpy_cross=mpy_cross,
-                     build_tools_version=build_tools_version,
-                     pkg_folder_prefix=package_folder_prefix)
+        build_bundle(libs, bundle_version, zip_filename, package_folder_prefix,
+                     mpy_cross=mpy_cross, build_tools_version=build_tools_version)
 
     # Build example bundle
     zip_filename = os.path.join(output_directory,
         filename_prefix + '-examples-{VERSION}.zip'.format(
             VERSION=bundle_version))
-    build_bundle(libs, bundle_version, zip_filename,
+    build_bundle(libs, bundle_version, zip_filename, package_folder_prefix,
                  build_tools_version=build_tools_version, example_bundle=True)

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -137,7 +137,7 @@ def _find_libraries(current_path, depth):
 @click.option('--library_location', required=True, help="Location of libraries to bundle.")
 @click.option('--library_depth', default=0, help="Depth of library folders. This is useful when multiple libraries are bundled together but are initially in separate subfolders.")
 @click.option('--package_folder_prefix', default=None, required=False, help="Prefix string used to determine package folders to bundle.")
-def build_bundles(filename_prefix, output_directory, library_location, library_depth, pkg_folder_prefix):
+def build_bundles(filename_prefix, output_directory, library_location, library_depth, package_folder_prefix):
     os.makedirs(output_directory, exist_ok=True)
 
     bundle_version = build.version_string()

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -49,7 +49,8 @@ def add_file(bundle, src_file, zip_name):
 
 
 def build_bundle(libs, bundle_version, output_filename,
-        build_tools_version="devel", mpy_cross=None, example_bundle=False):
+        build_tools_version="devel", mpy_cross=None, example_bundle=False,
+        pkg_folder_prefix=None):
     build_dir = "build-" + os.path.basename(output_filename)
     top_folder = os.path.basename(output_filename).replace(".zip", "")
     build_lib_dir = os.path.join(build_dir, top_folder, "lib")
@@ -69,8 +70,8 @@ def build_bundle(libs, bundle_version, output_filename,
     success = True
     for library_path in libs:
         try:
-            build.library(library_path, build_lib_dir, mpy_cross=mpy_cross,
-                          example_bundle=example_bundle)
+            build.library(library_path, build_lib_dir,  pkg_folder_prefix=pkg_folder_prefix,
+                          mpy_cross=mpy_cross, example_bundle=example_bundle)
         except ValueError as e:
             print("build.library failure:", library_path)
             print(e)
@@ -135,7 +136,8 @@ def _find_libraries(current_path, depth):
 @click.option('--output_directory', default="bundles", help="Output location for the zip files.")
 @click.option('--library_location', required=True, help="Location of libraries to bundle.")
 @click.option('--library_depth', default=0, help="Depth of library folders. This is useful when multiple libraries are bundled together but are initially in separate subfolders.")
-def build_bundles(filename_prefix, output_directory, library_location, library_depth):
+@click.option('--package_folder_prefix', default=None, required=False, help="Prefix string used to determine package folders to bundle.")
+def build_bundles(filename_prefix, output_directory, library_location, library_depth, pkg_folder_prefix):
     os.makedirs(output_directory, exist_ok=True)
 
     bundle_version = build.version_string()
@@ -158,6 +160,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
         filename_prefix + '-py-{VERSION}.zip'.format(
             VERSION=bundle_version))
     build_bundle(libs, bundle_version, zip_filename,
+                 pkg_folder_prefix=pkg_folder_prefix,
                  build_tools_version=build_tools_version)
 
     # Build .mpy bundle(s)
@@ -175,7 +178,8 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
                 TAG=version["name"],
                 VERSION=bundle_version))
         build_bundle(libs, bundle_version, zip_filename, mpy_cross=mpy_cross,
-                     build_tools_version=build_tools_version)
+                     build_tools_version=build_tools_version,
+                     pkg_folder_prefix=pkg_folder_prefix)
 
     # Build example bundle
     zip_filename = os.path.join(output_directory,

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -48,7 +48,7 @@ def add_file(bundle, src_file, zip_name):
     return file_sector_size
 
 
-def build_bundle(libs, bundle_version, output_filename, pkg_folder_prefix,
+def build_bundle(libs, bundle_version, output_filename, package_folder_prefix,
         build_tools_version="devel", mpy_cross=None, example_bundle=False):
     build_dir = "build-" + os.path.basename(output_filename)
     top_folder = os.path.basename(output_filename).replace(".zip", "")
@@ -69,7 +69,7 @@ def build_bundle(libs, bundle_version, output_filename, pkg_folder_prefix,
     success = True
     for library_path in libs:
         try:
-            build.library(library_path, build_lib_dir,  pkg_folder_prefix,
+            build.library(library_path, build_lib_dir,  package_folder_prefix,
                           mpy_cross=mpy_cross, example_bundle=example_bundle)
         except ValueError as e:
             print("build.library failure:", library_path)


### PR DESCRIPTION
Attempt number 2; original attempt was in #31.

This version defaults `package_folder_prefix` to `adafruit_`, so that every .travis.yml doesn't need to be updated.