### PR TITLE
Retain Full Subfolder Structure In Packages

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -100,7 +100,8 @@ def _munge_to_temp(original_path, temp_file, library_version):
                 temp_file.write(line.encode("utf-8") + b"\r\n")
     temp_file.flush()
 
-def library(library_path, output_directory, package_folder_prefix, mpy_cross=None, example_bundle=False):
+def library(library_path, output_directory, package_folder_prefix,
+            mpy_cross=None, example_bundle=False):
     py_files = []
     package_files = []
     example_files = []
@@ -118,7 +119,8 @@ def library(library_path, output_directory, package_folder_prefix, mpy_cross=Non
                 if filename.startswith("examples"):
                     path_tail_idx = path[0].rfind("examples/") + 9
                 else:
-                    path_tail_idx = path[0].rfind("/") + 1
+                    path_tail_idx = (path[0].rfind("{}/".format(filename))
+                                     + (len(filename) +1))
                 path_tail = path[0][path_tail_idx:]
                 rel_path = ""
                 # if this entry is the package top dir, keep it
@@ -130,7 +132,10 @@ def library(library_path, output_directory, package_folder_prefix, mpy_cross=Non
                     walked_files.append("{}{}".format(rel_path, path_files))
             #print(" - expanded file walk: {}".format(walked_files))
 
-            files = filter(lambda x: x.endswith(".py") or x.startswith("font5x8.bin"), walked_files)
+            files = filter(
+                lambda x: x.endswith(".py") or x.startswith("font5x8.bin"),
+                walked_files
+            )
             files = map(lambda x: os.path.join(filename, x), files)
 
             if filename.startswith("examples"):
@@ -139,7 +144,7 @@ def library(library_path, output_directory, package_folder_prefix, mpy_cross=Non
             else:
                 if (not example_bundle and
                     not filename.startswith(package_folder_prefix)):
-                        #print("skipped path: {}".format(full_path))
+                        print("skipped path: {}".format(full_path))
                         continue
                 if not example_bundle:
                     package_files.extend(files)


### PR DESCRIPTION
As highlighted in a recent release attempt for `Adafruit_CircuitPython_ImageLoad`, sub-subfolders were dropping their immediate parent folder.

I did a regression test on an older full Bundle (~10 days old), and everything looks good.

Test result on the updated ImageLoad library, shows that subfolder structure is now retained:
```
~/Dev/cpy-build-tools:$> unzip -l test-2.x-mpy-930c053.zip
Archive:  test-2.x-mpy-930c053.zip
{"build-tools-version": "1.1.6.dev44+g67abd08"}
  Length      Date    Time    Name
---------  ---------- -----   ----
      600  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/__init__.mpy
      713  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/pbm_binary.mpy
      679  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/ppm_binary.mpy
     1242  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/__init__.mpy
      990  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/ppm_ascii.mpy
      425  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/pbm_ascii.mpy
      653  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/pgm/binary.mpy
      522  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/pgm/__init__.mpy
      934  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/pnm/pgm/ascii.mpy
      771  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/bmp/__init__.mpy
      687  2019-05-31 18:46   test-2.x-mpy-930c053/lib/adafruit_imageload/bmp/indexed.mpy
      457  2019-05-31 18:46   test-2.x-mpy-930c053/examples/imageload_colorwheel.py
     1232  2019-05-31 18:46   test-2.x-mpy-930c053/examples/imageload_netpbm.py
      244  2019-05-31 18:46   test-2.x-mpy-930c053/examples/imageload_simpletest.py
---------                     -------
    10149                     14 files
```