### PR TITLE
Fix Example Bundling When 'examples' In Subfolder Name

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -116,17 +116,21 @@ def library(library_path, output_directory, package_folder_prefix,
             # 'walked_files' while retaining subdirectory structure
             walked_files = []
             for path in path_walk:
+                rel_path = ""
                 if filename.startswith("examples"):
-                    path_tail_idx = path[0].rfind("examples/") + 9
+                    path_tail_idx = path[0].rfind("examples/")
+                    if path_tail_idx != -1:
+                        rel_path = "{}/".format(path[0][path_tail_idx + 9:])
+
                 else:
                     path_tail_idx = (path[0].rfind("{}/".format(filename))
                                      + (len(filename) +1))
-                path_tail = path[0][path_tail_idx:]
-                rel_path = ""
-                # if this entry is the package top dir, keep it
-                # empty so we don't double append the dir name
-                if filename not in path_tail:
-                    rel_path = "{}/".format(path_tail)
+                    path_tail = path[0][path_tail_idx:]
+
+                    # if this entry is the package top dir, keep it
+                    # empty so we don't double append the dir name
+                    if filename not in path_tail:
+                        rel_path = "{}/".format(path_tail)
 
                 for path_files in path[2]:
                     walked_files.append("{}{}".format(rel_path, path_files))
@@ -151,8 +155,8 @@ def library(library_path, output_directory, package_folder_prefix,
                     #print("- package files: {} | {}".format(filename, package_files))
 
         if (filename.endswith(".py") and
-           filename not in IGNORE_PY and
-           not example_bundle):
+            filename not in IGNORE_PY and
+            not example_bundle):
                 py_files.append(filename)
 
     if len(py_files) > 1:


### PR DESCRIPTION
As discovered in Adafruit_CircuitPython_CircuitPlayground [PR #67](https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/pull/67), if a subfolder in the examples directory contained the word `examples` the file path would be truncated.

This fixes the truncation when dealing with the examples folder. Example using the above PR:
```shell
Generating VERSIONS

Zipping
test-examples-800ee1a/examples/circuitplayground_acceleration.py 155 512
test-examples-800ee1a/examples/circuitplayground_temperture.py 453 512
test-examples-800ee1a/examples/circuitplayground_light_plotter.py 394 512
test-examples-800ee1a/examples/circuitplayground_play_tone.py 247 512
test-examples-800ee1a/examples/circuitplayground_touch_pixel_fill_rainbow.py 1030 1536
test-examples-800ee1a/examples/circuitplayground_tapdetect.py 149 512
test-examples-800ee1a/examples/circuitplayground_play_file.py 411 512
test-examples-800ee1a/examples/circuitplayground_play_tone_buttons.py 268 512
test-examples-800ee1a/examples/circuitplayground_slide_switch_red_led_short.py 265 512
test-examples-800ee1a/examples/circuitplayground_temperature_neopixels.py 1134 1536
test-examples-800ee1a/examples/circuitplayground_tapdetect_single_double.py 527 1024
test-examples-800ee1a/examples/circuitplayground_ir_transmit.py 1354 1536
test-examples-800ee1a/examples/circuitplayground_neopixel_0_1.py 252 512
test-examples-800ee1a/examples/circuitplayground_red_led.py 140 512
test-examples-800ee1a/examples/circuitplayground_touched.py 452 512
test-examples-800ee1a/examples/circuitplayground_temperture_plotter.py 526 1024
test-examples-800ee1a/examples/circuitplayground_touch_pixel_rainbow.py 1017 1024
test-examples-800ee1a/examples/circuitplayground_buttons_1_neopixel.py 532 1024
test-examples-800ee1a/examples/circuitplayground_tone.py 207 512
test-examples-800ee1a/examples/circuitplayground_shake.py 140 512
test-examples-800ee1a/examples/circuitplayground_tap_red_led.py 396 512
test-examples-800ee1a/examples/circuitplayground_play_file_buttons.py 563 1024
test-examples-800ee1a/examples/circuitplayground_buttons_neopixels.py 565 1024
test-examples-800ee1a/examples/circuitplayground_slide_switch_red_led.py 345 512
test-examples-800ee1a/examples/circuitplayground_acceleration_neopixels.py 952 1024
test-examples-800ee1a/examples/circuitplayground_sound_meter.py 1871 2048
test-examples-800ee1a/examples/circuitplayground_button_b.py 432 512
test-examples-800ee1a/examples/circuitplayground_light_neopixels.py 929 1024
test-examples-800ee1a/examples/circuitplayground_red_led_blinky.py 284 512
test-examples-800ee1a/examples/circuitplayground_light.py 353 512
test-examples-800ee1a/examples/circuitplayground_slide_switch.py 283 512
test-examples-800ee1a/examples/circuitplayground_ir_receive.py 1480 1536
test-examples-800ee1a/examples/circuitplayground_button_a.py 227 512
test-examples-800ee1a/examples/circuitplayground_red_led_blnky_short.py 301 512
test-examples-800ee1a/examples/circuitplayground_pixels_simpletest.py 961 1024
test-examples-800ee1a/examples/advanced_examples/circuitplayground_acceleration_mapping_neopixels.py 1860 2048
test-examples-800ee1a/examples/advanced_examples/circuitplayground_gravity_pulls_pixel.py 3367 3584
```

Regression test on the full bundle also passed.