### PR TITLE
Allow Multiple Package Folder Prefixes; Improve File Gathering

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (c) 2016 Scott Shawcroft for Adafruit Industries
+#               2018, 2019 Michael Schroeder
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -116,12 +117,16 @@ def library(library_path, output_directory, package_folder_prefix,
         glob_search.extend(list(lib_path.rglob(pattern)))
 
     for file in glob_search:
-        #print(file_tree, ":", parent_idx)
         if file.parts[parent_idx] == "examples":
             example_files.append(file)
         else:
             if not example_bundle:
-                if file.parts[parent_idx].startswith(package_folder_prefix):
+                is_package = False
+                for prefix in package_folder_prefix:
+                    if file.parts[parent_idx].startswith(prefix):
+                        is_package = True
+
+                if is_package:
                     package_files.append(file)
                 else:
                     if file.name in IGNORE_PY:
@@ -131,8 +136,8 @@ def library(library_path, output_directory, package_folder_prefix,
                         py_files.append(file)
 
     if len(py_files) > 1:
-        raise ValueError("Multiple top level py files not allowed. Please put them in a package "
-                         "or combine them into a single file.")
+        raise ValueError("Multiple top level py files not allowed. Please put "
+                         "them in a package or combine them into a single file.")
 
     for fn in example_files:
         base_dir = os.path.join(output_directory.replace("/lib", "/"),
@@ -142,7 +147,8 @@ def library(library_path, output_directory, package_folder_prefix,
             total_size += 512
 
     for fn in package_files:
-        base_dir = os.path.join(output_directory, fn.relative_to(library_path).parent)
+        base_dir = os.path.join(output_directory,
+                                fn.relative_to(library_path).parent)
         if not os.path.isdir(base_dir):
             os.makedirs(base_dir)
             total_size += 512

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -139,6 +139,8 @@ def _find_libraries(current_path, depth):
 def build_bundles(filename_prefix, output_directory, library_location, library_depth, package_folder_prefix):
     os.makedirs(output_directory, exist_ok=True)
 
+    package_folder_prefix = package_folder_prefix.split(", ")
+
     bundle_version = build.version_string()
 
     libs = _find_libraries(os.path.abspath(library_location), library_depth)


### PR DESCRIPTION
- Multiple entries can now be used with the `package_folder_prefix` argument. Allows [Community Bundle #27](https://github.com/adafruit/CircuitPython_Community_Bundle/issues/27) to be addressed.

- Improves file gathering by switching from `os.walk()` to using `pathlib`. While it processes more files (files from the `build_dep` folders get dragged in when mpy'ing), its actually a bit faster by my eyes. More importantly in my opinion, its much more readable/maintainable than my previous `os.walk` monstrosity. Also, with the new glob pattern searching, its easier to handle additional file [types] in the future.

Passed regression testing on both bundles, and both a package and non-package library.