### PR TITLE
Properly Truncate mpy Filenames

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -174,10 +174,12 @@ def library(library_path, output_directory, package_folder_prefix,
             _munge_to_temp(full_path, temp_file, library_version)
 
             if mpy_cross:
-                mpy_success = subprocess.call([mpy_cross,
-                                               "-o", output_file,
-                                               "-s", str(filename),
-                                               temp_file.name])
+                mpy_success = subprocess.call([
+                    mpy_cross,
+                    "-o", output_file,
+                    "-s", str(filename.relative_to(library_path)),
+                    temp_file.name
+                ])
                 if mpy_success != 0:
                     raise RuntimeError("mpy-cross failed on", full_path)
             else:
@@ -197,10 +199,12 @@ def library(library_path, output_directory, package_folder_prefix,
                     filename.relative_to(library_path).with_suffix(new_extension)
                 )
 
-                mpy_success = subprocess.call([mpy_cross,
-                                               "-o", output_file,
-                                               "-s", str(filename),
-                                               temp_file.name])
+                mpy_success = subprocess.call([
+                    mpy_cross,
+                    "-o", output_file,
+                    "-s", str(filename.relative_to(library_path)),
+                    temp_file.name
+                ])
                 if mpy_success != 0:
                     raise RuntimeError("mpy-cross failed on", full_path)
 


### PR DESCRIPTION
Fixes #51.

```
(.env) > cat build-test-4.x-mpy-318fa70.zip/test-4.x-mpy-318fa70/lib/adafruit_bitmap_font/bitmap_font.mpy

5��%e�$$P▒a$<module>#adafruit_bitmap_font/bitmap_font.py
__version___repo__      load_fonts0.0.1-alpha.0.plus.24+1c0d724sB
https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font.git�.
▒�. $&%*H3.)3&(3&(��6
��h²��▒dó▒�fİ�7���7��2���f[��f7���7��hƶ �f[��!f7���7��h!Ƿ#�f[[        
load_font#adafruit_bitmap_font/bitmap_font.py   
displayioBitmapopenrbreaendswithbdfbdfbdfBDendswithpcfpcfPCendswithttfttfTTfilenamebitmapbSTARbfcpb
```

_Compare `<module>#adafruit_bitmap_font/bitmap_font.py` here to the result in 51._

