### PR TITLE
Added `ssh://git@` url pattern

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -91,7 +91,9 @@ def build_bundle(libs, bundle_version, output_filename, package_folder_prefix,
             for line in versions.stdout.split(b"\n"):
                 if not line:
                     continue
-                if line.startswith(b"git@"):
+                if line.startswith(b"ssh://git@"):
+                    repo = b"https://" + line.split(b"@")[1][:-len(".git")]
+                elif line.startswith(b"git@"):
                     repo = b"https://github.com/" + line.split(b":")[1][:-len(".git")]
                 elif line.startswith(b"https:"):
                     repo = line.strip()[:-len(".git")]


### PR DESCRIPTION
```
➜ git submodule --quiet foreach "git remote get-url origin && git describe --tags"
ssh://git@github.com/adafruit/Adafruit_CircuitPython_74HC595.git
1.0.3
ssh://git@github.com/adafruit/Adafruit_CircuitPython_ADS1x15.git
2.1.1
ssh://git@github.com/adafruit/Adafruit_CircuitPython_ADT7410.git
1.0.1
```

Added support for this git remote url syntax