### PR TITLE
Fix requirements missing for single file modules

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -122,9 +122,10 @@ def library(library_path, output_directory, package_folder_prefix,
         else:
             if not example_bundle:
                 is_package = False
-                for prefix in package_folder_prefix:
-                    if file.parts[parent_idx].startswith(prefix):
-                        is_package = True
+                if len(file.parts) > parent_idx + 1:
+                    for prefix in package_folder_prefix:
+                        if file.parts[parent_idx].startswith(prefix):
+                            is_package = True
 
                 if is_package:
                     package_files.append(file)


### PR DESCRIPTION
Requirements files are missing from the bundle for single file modules.

The cause is that the files are wrongly identified as being packages. This causes in turn the `module_name` to be `None` and the requirement file to be skipped.
To fix this we first test if the file even is in a sub directory.

I performed limited local tests with a single file module and a package module.
Fixes https://github.com/adafruit/circup/issues/89