### PR TITLE
Added JSON generator for bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ circuitpython_build_tools/data/
 .eggs
 version.py
 .env/*
+.DS_Store


### PR DESCRIPTION
As needed for https://github.com/adafruit/circuitpython-org/issues/491. Originally, I had intended to add this functionality to adabot, but ultimately decided this was the correct place as part of the bundle because I could get the exact paths inside the bundle. This also gives the flexibility to add the JSON functionality if we were to add more bundles.