### PR TITLE
Bundle JSON improvements

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -227,7 +227,6 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
     if pkg:
         build_tools_version = pkg.version
 
-    """
     build_tools_fn = "z-build_tools_version-{}.ignore".format(
         build_tools_version)
     build_tools_fn = os.path.join(output_directory, build_tools_fn)
@@ -264,7 +263,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
             VERSION=bundle_version))
     build_bundle(libs, bundle_version, zip_filename, package_folder_prefix,
                  build_tools_version=build_tools_version, example_bundle=True)
-    """
+
     # Build Bundle JSON
     json_filename = os.path.join(output_directory,
         filename_prefix + '-{VERSION}.json'.format(

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -39,7 +39,7 @@ from circuitpython_build_tools import target_versions
 
 import pkg_resources
 
-NOT_BUNDLE_LIBRARIES = [
+LINUX_LIBRARIES = [
     "adafruit-blinka",
     "adafruit-blinka-bleio",
     "adafruit-blinka-displayio",
@@ -56,20 +56,22 @@ def add_file(bundle, src_file, zip_name):
     return file_sector_size
 
 def get_module_name(library_path):
-    """Figure out the module or package name anbd return it"""
-    url = subprocess.run('git remote get-url origin', shell=True, stdout=subprocess.PIPE, cwd=library_path)
-    url = url.stdout.decode("utf-8", errors="ignore").strip().lower()
-    module_name = url[:-4].split("/")[-1].replace("_", "-")
-    return module_name
+    """Figure out the module or package name and return it"""
+    repo = subprocess.run('git remote get-url origin', shell=True, stdout=subprocess.PIPE, cwd=library_path)
+    repo = repo.stdout.decode("utf-8", errors="ignore").strip().lower()
+    module_name = repo[:-4].split("/")[-1].replace("_", "-")
+    return module_name, repo
 
-def get_bundle_requirements(directory):
+def get_bundle_requirements(directory, package_list):
     """
     Open the requirements.txt if it exists
     Remove anything that shouldn't be a requirement like Adafruit_Blinka
     Return the list
     """
     
-    libraries = []
+    pypi_reqs = []   # For multiple bundle dependency
+    dependencies = []   # For intra-bundle dependency
+    
     path = directory + "/requirements.txt"
     if os.path.exists(path):
         with open(path, "r") as file:
@@ -84,25 +86,39 @@ def get_bundle_requirements(directory):
                     if any(operators in line for operators in [">", "<", "="]):
                         # Remove everything after any pip style version specifiers
                         line = re.split("[<|>|=|]", line)[0]
-                    if line not in libraries and line not in NOT_BUNDLE_LIBRARIES:
-                        libraries.append(line)
-    return libraries
+                    if line not in dependencies and line in package_list:
+                        dependencies.append(package_list[line]["module_name"])
+                    elif line not in pypi_reqs and line not in LINUX_LIBRARIES:
+                        pypi_reqs.append(line)
+    return dependencies, pypi_reqs
 
 def build_bundle_json(libs, bundle_version, output_filename, package_folder_prefix):
     """
     Generate a JSON file of all the libraries in libs
     """
-    library_submodules = {}
+    packages = {}
     for library_path in libs:
-        library = {}
+        package = {}
         package_info = build.get_package_info(library_path, package_folder_prefix)
-        module_name = get_module_name(library_path)
+        module_name, repo = get_module_name(library_path)
         if package_info["module_name"] is not None:
-            library["package"] = package_info["is_package"]
-            library["version"] = package_info["version"]
-            library["path"] = "lib/" + package_info["module_name"]
-            library["dependencies"] = get_bundle_requirements(library_path)
-            library_submodules[module_name] = library
+            package["module_name"] = package_info["module_name"]
+            package["repo"] = repo
+            package["is_folder"] = package_info["is_package"]
+            package["version"] = package_info["version"]
+            package["path"] = "lib/" + package_info["module_name"]
+            package["library_path"] = library_path
+            packages[module_name] = package
+
+    library_submodules = {}
+    for id in packages:
+        library = {}
+        library["package"] = packages[id]["is_folder"]
+        library["version"] = packages[id]["version"]
+        library["repo"] = packages[id]["repo"]
+        library["path"] = packages[id]["path"]
+        library["dependencies"], library["external_dependencies"] = get_bundle_requirements(packages[id]["library_path"], packages)
+        library_submodules[packages[id]["module_name"]] = library
     out_file = open(output_filename, "w")
     json.dump(library_submodules, out_file)
     out_file.close()
@@ -211,6 +227,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
     if pkg:
         build_tools_version = pkg.version
 
+    """
     build_tools_fn = "z-build_tools_version-{}.ignore".format(
         build_tools_version)
     build_tools_fn = os.path.join(output_directory, build_tools_fn)
@@ -247,7 +264,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
             VERSION=bundle_version))
     build_bundle(libs, bundle_version, zip_filename, package_folder_prefix,
                  build_tools_version=build_tools_version, example_bundle=True)
-
+    """
     # Build Bundle JSON
     json_filename = os.path.join(output_directory,
         filename_prefix + '-{VERSION}.json'.format(

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -39,10 +39,12 @@ from circuitpython_build_tools import target_versions
 
 import pkg_resources
 
-LINUX_LIBRARIES = [
+BLINKA_LIBRARIES = [
     "adafruit-blinka",
     "adafruit-blinka-bleio",
     "adafruit-blinka-displayio",
+    "adafruit-blinka-pyportal",
+    "adafruit-python-extended-bus",
     "pyserial",
 ]
 
@@ -88,7 +90,7 @@ def get_bundle_requirements(directory, package_list):
                         line = re.split("[<|>|=|]", line)[0]
                     if line not in dependencies and line in package_list:
                         dependencies.append(package_list[line]["module_name"])
-                    elif line not in pypi_reqs and line not in LINUX_LIBRARIES:
+                    elif line not in pypi_reqs and line not in BLINKA_LIBRARIES:
                         pypi_reqs.append(line)
     return dependencies, pypi_reqs
 

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -103,6 +103,7 @@ def build_bundle_json(libs, bundle_version, output_filename, package_folder_pref
         module_name, repo = get_module_name(library_path)
         if package_info["module_name"] is not None:
             package["module_name"] = package_info["module_name"]
+            package["pypi_name"] = module_name
             package["repo"] = repo
             package["is_folder"] = package_info["is_package"]
             package["version"] = package_info["version"]
@@ -114,6 +115,7 @@ def build_bundle_json(libs, bundle_version, output_filename, package_folder_pref
     for id in packages:
         library = {}
         library["package"] = packages[id]["is_folder"]
+        library["pypi_name"] = packages[id]["pypi_name"]
         library["version"] = packages[id]["version"]
         library["repo"] = packages[id]["repo"]
         library["path"] = packages[id]["path"]


### PR DESCRIPTION
Changes:
 * The libraries are listed by module name rather than PyPI name to make parsing easier
 * A link to the repo is included (for plugins)
 * Dependencies split into dependencies and external_dependencies depending on whether the requirement exists in the current bundle to make the Community Bundle easier to work with.
 * Variable name improvements to better represent their purpose
 * Added PyPI Name for external package matching