### PR TITLE
Use mpy-cross from S3 if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: python
 python:
-- '3.6'
+- '3.7'
 
 stages:
   - name: Tests
@@ -13,7 +13,7 @@ jobs:
   include:
     - stage: Tests
       name: "Test CircuitPython Bundle"
-      python: "3.6"
+      python: "3.7"
       script:
         - echo "Building mpy-cross" && echo "travis_fold:start:mpy-cross"
         - python3 -u -m circuitpython_build_tools.scripts.build_mpy_cross circuitpython_build_tools/data/

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -71,7 +71,7 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
     # Try to pull from S3
     uname = os.uname()
     s3_url = None
-    if uname[0] == 'Linux' and uname[4] == 'amd64':
+    if uname[0] == 'Linux' and uname[4] in ('amd64', 'x86_64'):
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-amd64-linux-{circuitpython_tag}"
     elif uname[0] == 'Linux' and uname[4] == 'armv7l':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-raspbian-{circuitpython_tag}"

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -73,10 +73,10 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
     s3_url = None
     if uname[0] == 'Linux' and uname[4] == 'amd64':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-amd64-linux-{circuitpython_tag}"
-        print(s3_url)
     elif uname[0] == 'Linux' and uname[4] == 'armv7l':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-raspbian-{circuitpython_tag}"
-        print(s3_url)
+    elif uname[0] == 'Darwin' and uname[4] == 'x86_64':
+        s3_url = f"{S3_MPY_PREFIX}mpy-cross-macos-catalina-{circuitpython_tag}"
     else:
         print(f"\nUnable to check S3 for sysname='{uname[0]}' release='{uname[2]}' machine='{uname[4]}'.")
         print("  Please file an issue at https://github.com/adafruit/circuitpython-build-tools/ with the above message")

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -83,7 +83,7 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
 
     if s3_url is not None:
         print(f"Checking S3 for {s3_url}")
-	try:
+        try:
             r = requests.get(s3_url)
             if r.status_code == 200:
                 with open(mpy_cross_filename, "wb") as f:

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -4,6 +4,7 @@
 #
 # Copyright (c) 2016 Scott Shawcroft for Adafruit Industries
 #               2018, 2019 Michael Schroeder
+#               2021 James Carr
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -78,12 +78,12 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-raspbian-{circuitpython_tag}"
     elif uname[0] == 'Darwin' and uname[4] == 'x86_64':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross-macos-catalina-{circuitpython_tag}"
-    else:
-        print(f"\nUnable to check S3 for sysname='{uname[0]}' release='{uname[2]}' machine='{uname[4]}'.")
-        print("  Please file an issue at https://github.com/adafruit/circuitpython-build-tools/ with the above message")
+    elif not quiet:
+         print(f"Pre-built mpy-cross not available for sysname='{uname[0]}' release='{uname[2]}' machine='{uname[4]}'.")
 
     if s3_url is not None:
-        print(f"Checking S3 for {s3_url}")
+        if not quiet:
+            print(f"Checking S3 for {s3_url}")
         try:
             r = requests.get(s3_url)
             if r.status_code == 200:
@@ -91,11 +91,14 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
                     f.write(r.content)
                     # Set the User Execute bit
                     os.chmod(mpy_cross_filename, os.stat(mpy_cross_filename)[0] | stat.S_IXUSR)
-                    print("  FOUND")
+                    if not quiet:
+                        print("  FOUND")
                     return
         except Exception as e:
-            print(f"    exception fetching from S3: {e}")
-        print("  NOT FOUND")
+            if not quiet:
+                print(f"    exception fetching from S3: {e}")
+        if not quiet:
+            print("  NOT FOUND")
 
     if not quiet:
         title = "Building mpy-cross for circuitpython " + circuitpython_tag

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -83,14 +83,17 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
 
     if s3_url is not None:
         print(f"Checking S3 for {s3_url}")
-        r = requests.get(s3_url)
-        if r.status_code == 200:
-            with open(mpy_cross_filename, "wb") as f:
-                f.write(r.content)
-                # Set the User Execute bit
-                os.chmod(mpy_cross_filename, os.stat(mpy_cross_filename)[0] | stat.S_IXUSR)
-                print("  FOUND")
-                return
+	try:
+            r = requests.get(s3_url)
+            if r.status_code == 200:
+                with open(mpy_cross_filename, "wb") as f:
+                    f.write(r.content)
+                    # Set the User Execute bit
+                    os.chmod(mpy_cross_filename, os.stat(mpy_cross_filename)[0] | stat.S_IXUSR)
+                    print("  FOUND")
+                    return
+        except Exception as e:
+            print(f"    exception fetching from S3: {e}")
         print("  NOT FOUND")
 
     if not quiet:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Click
+requests
 semver
 wheel

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='circuitpython-build-tools',
       package_data={'circuitpython_build_tools': ['data/mpy-cross-*']},
       zip_safe=False,
       python_requires='>=3.4',
-      install_requires=['Click', 'semver'],
+      install_requires=['Click', 'requests', 'semver'],
       entry_points='''
         [console_scripts]
         circuitpython-build-bundles=circuitpython_build_tools.scripts.build_bundles:build_bundles

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='circuitpython-build-tools',
                 'circuitpython_build_tools.scripts'],
       package_data={'circuitpython_build_tools': ['data/mpy-cross-*']},
       zip_safe=False,
-      python_requires='>=3.4',
+      python_requires='>=3.7',
       install_requires=['Click', 'requests', 'semver'],
       entry_points='''
         [console_scripts]


### PR DESCRIPTION
Closes #55

This PR attempts to download `mpy-cross` from S3 before building locally as a fall-back.

Local Tests:
* `raspian` - Raspberry Pi4 32bit - Linux 5.10.17-v7l+ armv7l - SUCCESS
* `macos-catalina` - macOS Catalina - 10.15.7 - SUCCESS

Github Testing:
Impossible on the main repo, so some test repos with differences where necessary.
https://github.com/lesamouraipourpre/samourai-build-tools
https://pypi.org/project/samourai-build-tools/
https://github.com/lesamouraipourpre/Samourai_CircuitPython_DPS310/tree/samourai-build-tools-test
https://github.com/lesamouraipourpre/Samourai_CircuitPython_DPS310/releases/tag/0.0.1-beta.3
https://pypi.org/project/samourai-circuitpython-dps310/
_Note: These will be removed once this PR is closed._

* `amd64-linux` - tested as part of Github actions above showing as Linux-x86_64 from uname. This is the main target of this PR and it is noticeably faster when the library Gihub actions run.

Not implemented - these will continue to build `mpy-cross` every time
* `x64-windows` - unable to test - the original `circuitpython-build-tools` fails in my Windows/Python environment with `PermissionError` when copying files. I don't use Windows for development so I've put no effort into fixing it.
* `aarch64` - not certain what this is. I assume it is Raspbian 64bit or Ubuntu 64bit on Raspberry Pi. I don't currently have either.

This probably needs further testing from those with more detailed knowledge of the build process.