### PR TITLE
update tag for 7.x

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -26,5 +26,5 @@
 # The name is used when constructing the zip file names.
 VERSIONS = [
     {"tag": "6.3.0", "name": "6.x"},
-    {"tag": "7.0.0-alpha.3", "name": "7.x"},
+    {"tag": "7.0.0", "name": "7.x"},
 ]


### PR DESCRIPTION
I noticed that CI is building mpy-cross, because the 7.0.0-alpha.3 mpy-cross binary has been moved away.  This will (slightly) speed builds with circuitpython-build-tools.