### PR TITLE
Stop supporting 6.x in the bundles

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -25,6 +25,5 @@
 # The tag specifies which version of CircuitPython to use for mpy-cross.
 # The name is used when constructing the zip file names.
 VERSIONS = [
-    {"tag": "6.3.0", "name": "6.x"},
     {"tag": "7.0.0", "name": "7.x"},
 ]


### PR DESCRIPTION
Libraries are being updated for 7.0.0 only which has been out since September 20th, 2021.

I've updated the FAQ with the last bundle: https://learn.adafruit.com/welcome-to-circuitpython/frequently-asked-questions