### PR TITLE
Windows compatibility

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -80,9 +80,7 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
     elif uname[0].title() == 'Darwin' and uname[4].lower() == 'x86_64':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross-macos-catalina-{circuitpython_tag}"
     elif uname[0].title() == "Windows" and uname[4].lower() in ("amd64", "x86_64"):
-        # prebuilt mpy-cross binary executable does not seem to exist on AWS.
-        # this URL triggers a "NOT FOUND" prompt below, then attempts to build from src
-        s3_url = f"{S3_MPY_PREFIX}mpy-cross-windows-{circuitpython_tag}"
+        s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-x64-windows-{circuitpython_tag}.exe"
     elif not quiet:
          print(f"Pre-built mpy-cross not available for sysname='{uname[0]}' release='{uname[2]}' machine='{uname[4]}'.")
 

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -26,6 +26,7 @@
 
 import os
 import os.path
+import platform
 import pathlib
 import requests
 import semver
@@ -70,14 +71,18 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
         return
 
     # Try to pull from S3
-    uname = os.uname()
+    uname = platform.uname()
     s3_url = None
-    if uname[0] == 'Linux' and uname[4] in ('amd64', 'x86_64'):
+    if uname[0].title() == 'Linux' and uname[4].lower() in ('amd64', 'x86_64'):
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-amd64-linux-{circuitpython_tag}"
-    elif uname[0] == 'Linux' and uname[4] == 'armv7l':
+    elif uname[0].title() == 'Linux' and uname[4].lower() == 'armv7l':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross.static-raspbian-{circuitpython_tag}"
-    elif uname[0] == 'Darwin' and uname[4] == 'x86_64':
+    elif uname[0].title() == 'Darwin' and uname[4].lower() == 'x86_64':
         s3_url = f"{S3_MPY_PREFIX}mpy-cross-macos-catalina-{circuitpython_tag}"
+    elif uname[0].title() == "Windows" and uname[4].lower() in ("amd64", "x86_64"):
+        # prebuilt mpy-cross binary executable does not seem to exist on AWS.
+        # this URL triggers a "NOT FOUND" prompt below, then attempts to build from src
+        s3_url = f"{S3_MPY_PREFIX}mpy-cross-windows-{circuitpython_tag}"
     elif not quiet:
          print(f"Pre-built mpy-cross not available for sysname='{uname[0]}' release='{uname[2]}' machine='{uname[4]}'.")
 
@@ -121,10 +126,11 @@ def mpy_cross(mpy_cross_filename, circuitpython_tag, quiet=False):
     make = subprocess.run("make clean && make", shell=True)
     os.chdir(current_dir)
 
-    shutil.copy("build_deps/circuitpython/mpy-cross/mpy-cross", mpy_cross_filename)
-
     if make.returncode != 0:
+        print("Failed to build mpy-cross from source... bailing out")
         sys.exit(make.returncode)
+
+    shutil.copy("build_deps/circuitpython/mpy-cross/mpy-cross", mpy_cross_filename)
 
 def _munge_to_temp(original_path, temp_file, library_version):
     with open(original_path, "rb") as original_file:
@@ -171,7 +177,7 @@ def get_package_info(library_path, package_folder_prefix):
         package_info["module_name"] = py_files[0].relative_to(library_path).name[:-3]
     else:
         package_info["module_name"] = None
- 
+
     try:
         package_info["version"] = version_string(library_path, valid_semver=True)
     except ValueError as e:
@@ -254,7 +260,9 @@ def library(library_path, output_directory, package_folder_prefix,
             output_directory,
             filename.relative_to(library_path).with_suffix(new_extension)
         )
-        with tempfile.NamedTemporaryFile() as temp_file:
+        temp_filename = ""
+        mpy_success = 1
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             _munge_to_temp(full_path, temp_file, library_version)
 
             if mpy_cross:
@@ -264,10 +272,11 @@ def library(library_path, output_directory, package_folder_prefix,
                     "-s", str(filename.relative_to(library_path)),
                     temp_file.name
                 ])
-                if mpy_success != 0:
-                    raise RuntimeError("mpy-cross failed on", full_path)
-            else:
-                shutil.copyfile(temp_file.name, output_file)
+            temp_filename = temp_file.name
+        if mpy_cross and mpy_success != 0:
+            raise RuntimeError("mpy-cross failed on", full_path)
+        shutil.copyfile(temp_filename, output_file)
+        os.remove(temp_filename)
 
     for filename in package_files:
         full_path = os.path.join(library_path, filename)
@@ -276,7 +285,7 @@ def library(library_path, output_directory, package_folder_prefix,
             if not mpy_cross or os.stat(full_path).st_size == 0:
                 output_file = os.path.join(output_directory,
                                            filename.relative_to(library_path))
-                shutil.copyfile(temp_file.name, output_file)
+                temp_filename = temp_file.name
             else:
                 output_file = os.path.join(
                     output_directory,
@@ -291,6 +300,9 @@ def library(library_path, output_directory, package_folder_prefix,
                 ])
                 if mpy_success != 0:
                     raise RuntimeError("mpy-cross failed on", full_path)
+        if not mpy_cross or os.stat(full_path).st_size == 0:
+            shutil.copyfile(temp_file.name, output_file)
+            os.remove(temp_filename)
 
     requirements_files = lib_path.glob("requirements.txt*")
     requirements_files = [f for f in requirements_files if f.stat().st_size > 0]
@@ -312,6 +324,9 @@ def library(library_path, output_directory, package_folder_prefix,
         full_path = os.path.join(library_path, filename)
         output_file = os.path.join(output_directory.replace("/lib", "/"),
                                    filename.relative_to(library_path))
-        with tempfile.NamedTemporaryFile() as temp_file:
+        temp_filename = ""
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             _munge_to_temp(full_path, temp_file, library_version)
-            shutil.copyfile(temp_file.name, output_file)
+            temp_filename = temp_file.name
+        shutil.copyfile(temp_file.name, output_file)
+        os.remove(temp_filename)

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -257,7 +257,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
             mpy_cross = pkg_resources.resource_filename(
                 target_versions.__name__, "data/mpy-cross-" + version["name"])
         else:
-            mpy_cross = "build_deps/mpy-cross-" + version["name"]
+            mpy_cross = "build_deps/mpy-cross-" + version["name"] + (".exe" * (os.name == "nt"))
             build.mpy_cross(mpy_cross, version["tag"])
         zip_filename = os.path.join(output_directory,
             filename_prefix + '-{TAG}-mpy-{VERSION}.zip'.format(


### PR DESCRIPTION
This PR resolves #75 (& the duplicate #48 )

# Needs verification on a Mac
Due to switching from `os.uname()` to `platform.uname()`, I was able to confirm that usage on Linux is not broken, but I do not have a Mac to verify that this still works (I think it should).

Libraries that I've tested these changes on:
- [gmparis/CircuitPython_I2C_Button](https://github.com/gmparis/CircuitPython_I2C_Button) This has examples and a single .py module at lib root.
- [nRF24/CircuitPython_nRF24L01](https://github.com/nRF24/CircuitPython_nRF24L01) This is a full blown package (my personal baby) with examples and multiple modules (some in sub-packages).

## Changes
- switch to using `platform.uname()` since `os.uname()` is not available on Windows installs of CPython. In testing, I found that `platform.uname()` tends to yield different casing in the returned (tuple of) strings, so I mandated uniform string casing using `uname[0].title()` and `uname[4].lower()`.
- added URL to download a pre-built binary executable from AWS. mpy-cross cannot be built from src (on windows), and that is the build.py script's fallback behavior (when no internet or using Windows 32bit).
- Fixed copying temp files on Windows. The problem is well outlined in the #75. The solution simply involves exiting the `with` block that created the temp file (under the condition that the temp file is not deleted when it is closed), then copying the file (when applicable) and deleting the original temp file (using `os.remove()`).