### PR TITLE
Bump the mpy-cross version to 7.3.0

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -25,5 +25,5 @@
 # The tag specifies which version of CircuitPython to use for mpy-cross.
 # The name is used when constructing the zip file names.
 VERSIONS = [
-    {"tag": "7.0.0", "name": "7.x"},
+    {"tag": "7.3.0", "name": "7.x"},
 ]


### PR DESCRIPTION
In CP 7.3.0 there are some language fixes to previous syntax errors in f-strings (from MP18).
A string like this would not compile prior to 7.3.0:
```py
string = "123456789"
print(f"{string[2:6]}")
```
Note that an MPY file with that code generated with mpy-cross 7.3.0 runs properly on 7.0.0 according to my tests.