### PR TITLE
Generate Circuitpython 8.x bundle

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -26,4 +26,5 @@
 # The name is used when constructing the zip file names.
 VERSIONS = [
     {"tag": "7.3.0", "name": "7.x"},
+    {"tag": "8.0.0-alpha.1", "name": "8.x"},
 ]


### PR DESCRIPTION
Using current latest published mpy-cross for CP8.