### PR TITLE
build_bundles: Ignore more packages that exist only on pypi

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -44,7 +44,6 @@ BLINKA_LIBRARIES = [
     "adafruit_blinka_bleio",
     "adafruit_blinka_displayio",
     "adafruit_blinka_pyportal",
-    "adafruit_circuitpython_busdevice",
     "adafruit_python_extended_bus",
     "numpy",
     "pillow",


### PR DESCRIPTION
…and sort the existing list and use 'normalized' names

The implementation of normalize_dist_name is taken from pipkin. @aivarannamaa hopefully you can update this list once this PR is confirmed and merged.

@ladyada pipkin copies this list so we should make sure it's up to date on our end!

This list is based on all lines we list in a "requirements.txt" in the adafruit bundle, minutes the ones named adafruit-circuitpython-. Plus numpy and scipy which aren't actually _USED_ at this time, but are added speculatively since dual-purpose code can work with ulab or with numpy.