### PR TITLE
Fix listing dependencies in json

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -50,6 +50,7 @@ BLINKA_LIBRARIES = [
     "pyasn1",
     "pyserial",
     "scipy",
+    "spidev",
 ]
 
 def normalize_dist_name(name: str) -> str:


### PR DESCRIPTION
By converting dependencies to `_`, the 1.10.2 release scrambled the requirements in the json file, moving all "dependencies" to "external dependencies" with an underscored pypi name instead of the library name (`adafruit_circuitpython_hid` instead of `adafruit_hid`).

This PR uses `-` not `_` to reference modules from dependencies, so it matches the index used in `package_list` and the pypi_name field. Use the same function in both parts to emphasize their relatedness. The original name before transformation is still used in external_dependencies.

Note: this does not keep the same format as pipkin as intended by #90. pipkin can map the format function on the list to make sure every reference uses the same format without having to edit the list manually.

Additionally:
- Add `~[;` to filter requirements and strip() spaces. [See here examples of valid formats](https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples).
- Use sets to simplify the uniqueness test. Previously `if line in dependencies` would always be False. (testing the presence of `adafruit-circuitpython-dotstar` before adding `adafruit_dotstar`).
- Add `spidev` to the list of skipped dependencies. (Found in the community bundle).
- Sort the dependencies to make comparisons for that kind of check easier in the future. And use sort_keys in json, because why not.

With this PR the generated json matches the one generated by 1.10.1 except newly skipped libraries are skipped (`pyasn1`, `pillow`, `spidev`), and bad dependencies are fixed (`typing-extensions~`).
