### PR TITLE
Update to use mpy-cross-8.0.0 instead of 8.0.0-alpha.1

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -26,5 +26,5 @@
 # The name is used when constructing the zip file names.
 VERSIONS = [
     {"tag": "7.3.0", "name": "7.x"},
-    {"tag": "8.0.0-alpha.1", "name": "8.x"},
+    {"tag": "8.0.0", "name": "8.x"},
 ]


### PR DESCRIPTION
mpy-cross-8.0.0-alpha.1 was deleted recently; I didn't realize this was depending on it. So it was re-building mpy-cross for every library release.

The mpy-cross executables are being moved into directories. I'll fix this again after that is complete.