### PR TITLE
Allow bundles to be skipped

### DIFF
--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -234,10 +234,8 @@ def _find_libraries(current_path, depth):
 @click.option('--library_depth', default=0, help="Depth of library folders. This is useful when multiple libraries are bundled together but are initially in separate subfolders.")
 @click.option('--package_folder_prefix', default="adafruit_", help="Prefix string used to determine package folders to bundle.")
 @click.option('--remote_name', default="origin", help="Git remote name to use during building")
-@click.option('--ignore', default="", help="Bundles to ignore building")
+@click.option('--ignore', "-i", multiple=True, type=click.Choice(["py", "mpy", "example", "json"]), help="Bundles to ignore building")
 def build_bundles(filename_prefix, output_directory, library_location, library_depth, package_folder_prefix, remote_name, ignore):
-    skip_bundles = ignore.lower().split(", ")
-
     os.makedirs(output_directory, exist_ok=True)
 
     package_folder_prefix = package_folder_prefix.split(", ")
@@ -258,7 +256,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
         f.write(build_tools_version)
 
     # Build raw source .py bundle
-    if "py" not in skip_bundles:
+    if "py" not in ignore:
         zip_filename = os.path.join(output_directory,
             filename_prefix + '-py-{VERSION}.zip'.format(
                 VERSION=bundle_version))
@@ -266,7 +264,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
                     build_tools_version=build_tools_version, remote_name=remote_name)
 
     # Build .mpy bundle(s)
-    if "mpy" not in skip_bundles:
+    if "mpy" not in ignore:
         os.makedirs("build_deps", exist_ok=True)
         for version in target_versions.VERSIONS:
             # Use prebuilt mpy-cross on Travis, otherwise build our own.
@@ -284,7 +282,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
                         mpy_cross=mpy_cross, build_tools_version=build_tools_version, remote_name=remote_name)
 
     # Build example bundle
-    if "example" not in skip_bundles:
+    if "example" not in ignore:
         zip_filename = os.path.join(output_directory,
             filename_prefix + '-examples-{VERSION}.zip'.format(
                 VERSION=bundle_version))
@@ -292,7 +290,7 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
                     build_tools_version=build_tools_version, example_bundle=True, remote_name=remote_name)
 
     # Build Bundle JSON
-    if "json" not in skip_bundles:
+    if "json" not in ignore:
         json_filename = os.path.join(output_directory,
             filename_prefix + '-{VERSION}.json'.format(
                 VERSION=bundle_version))


### PR DESCRIPTION
Allows bundles to be skipped from being built.  This is useful when libraries that do not need specific bundles (e.g., `circuitpython_typing` does not need `.mpy` bundles) are built.