### PR TITLE
Stop building bundles for 7.x

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -25,6 +25,5 @@
 # The tag specifies which version of CircuitPython to use for mpy-cross.
 # The name is used when constructing the zip file names.
 VERSIONS = [
-    {"tag": "7.3.0", "name": "7.x"},
     {"tag": "8.0.0", "name": "8.x"},
 ]


### PR DESCRIPTION
This way we can update libraries for 8.x+. (Particularly changing `display.show()` to `display.root_group =`.)