### PR TITLE
Get package name from pyproject.toml, allow arbitrary files in packages

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -171,7 +171,7 @@ def get_package_info(library_path, package_folder_prefix):
     for pattern in GLOB_PATTERNS:
         glob_search.extend(list(lib_path.rglob(pattern)))
 
-    pyproject_toml = load_pyproject.toml(lib_path)
+    pyproject_toml = load_pyproject_toml(lib_path)
     py_modules = get_nested(pyproject_toml, "tool", "setuptools", "py-modules", default=[])
     packages = get_nested(pyproject_toml, "tool", "setuptools", "packages", default=[])
 

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -275,7 +275,7 @@ def library(library_path, output_directory, package_folder_prefix,
                     try:
                         _munge_to_temp(full_path, temp_file, library_version)
                         temp_file.close()
-                        if mpy_cross:
+                        if mpy_cross and os.stat(temp_file.name).st_size != 0:
                             output_file = output_file.with_suffix(".mpy")
                             mpy_success = subprocess.call([
                                 mpy_cross,

--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -41,11 +41,11 @@ if sys.version_info >= (3, 11):
 else:
     from tomli import loads as load_toml
 
-def load_settings_toml(lib_path: pathlib.Path):
+def load_pyproject_toml(lib_path: pathlib.Path):
     try:
         return load_toml((lib_path / "pyproject.toml") .read_text(encoding="utf-8"))
     except FileNotFoundError:
-        print(f"No settings.toml in {lib_path}")
+        print(f"No pyproject.toml in {lib_path}")
         return {}
 
 def get_nested(doc, *args, default=None):
@@ -171,9 +171,9 @@ def get_package_info(library_path, package_folder_prefix):
     for pattern in GLOB_PATTERNS:
         glob_search.extend(list(lib_path.rglob(pattern)))
 
-    settings_toml = load_settings_toml(lib_path)
-    py_modules = get_nested(settings_toml, "tool", "setuptools", "py-modules", default=[])
-    packages = get_nested(settings_toml, "tool", "setuptools", "packages", default=[])
+    pyproject_toml = load_pyproject.toml(lib_path)
+    py_modules = get_nested(pyproject_toml, "tool", "setuptools", "py-modules", default=[])
+    packages = get_nested(pyproject_toml, "tool", "setuptools", "packages", default=[])
 
     example_files = [sub_path for sub_path in (lib_path / "examples").rglob("*")
             if sub_path.is_file()]
@@ -185,7 +185,7 @@ def get_package_info(library_path, package_folder_prefix):
         if len(packages) > 1:
             raise ValueError("Only a single package is supported")
         package_name = packages[0]
-        print(f"Using package name from settings.toml: {package_name}")
+        print(f"Using package name from pyproject.toml: {package_name}")
         package_info["is_package"] = True
         package_info["module_name"] = package_name
         package_files = [sub_path for sub_path in (lib_path / package_name).rglob("*")
@@ -194,14 +194,14 @@ def get_package_info(library_path, package_folder_prefix):
     elif py_modules:
         if len(py_modules) > 1:
             raise ValueError("Only a single module is supported")
-        print("Using module name from settings.toml")
+        print("Using module name from pyproject.toml")
         py_module = py_modules[0]
         package_name = py_module
         package_info["is_package"] = False
         package_info["module_name"] = py_module
         py_files = [lib_path / f"{py_module}.py"]
 
-    if not packages and not py_modules:
+    else:
         print("Using legacy autodetection")
         package_info["is_package"] = False
         for file in glob_search:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Click
 requests
 semver
 wheel
+tomli; python_version < "3.11"


### PR DESCRIPTION
This is more dependable, and when we know the package name we can glob inside it to get all files such as bin or ttf files.

This will allow e.g., 5x8.bin & ov5640_autofocus.bin within
bundles.

the behavior of bundlefly and circup when encountering .bin files needs to be checked.

Tested by building modified pycamera bundle and the autofocus.bin file appears in the generated zip files:
```
pycamera-py-ec67bde/lib/adafruit_pycamera/ov5640_autofocus.bin 4077 4096
pycamera-8.x-mpy-ec67bde/lib/adafruit_pycamera/ov5640_autofocus.bin 4077 4096
pycamera-9.x-mpy-ec67bde/lib/adafruit_pycamera/ov5640_autofocus.bin 4077 4096
```

There's at least one library in the bundle that has incorrect metadata and that leads to an error:
    https://github.com/adafruit/Adafruit_CircuitPython_Colorsys/pull/29
