### PR TITLE
addresses #103

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.7
     - name: Versions
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install requirements
       run: |
         sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
   upload-pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.7'
     - name: Install dependencies

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -36,8 +36,6 @@ import click
 from circuitpython_build_tools import build
 from circuitpython_build_tools import target_versions
 
-import importlib.resources as importlib_resources
-
 if sys.version_info < (3, 8):
     import importlib_metadata
 else:
@@ -272,13 +270,8 @@ def build_bundles(filename_prefix, output_directory, library_location, library_d
     if "mpy" not in ignore:
         os.makedirs("build_deps", exist_ok=True)
         for version in target_versions.VERSIONS:
-            # Use prebuilt mpy-cross on Travis, otherwise build our own.
-            if "TRAVIS" in os.environ:
-                mpy_cross = importlib_resources.files(
-                    target_versions.__name__) / "data/mpy-cross-" + version["name"]
-            else:
-                mpy_cross = "build_deps/mpy-cross-" + version["name"] + (".exe" * (os.name == "nt"))
-                build.mpy_cross(mpy_cross, version["tag"])
+            mpy_cross = "build_deps/mpy-cross-" + version["name"] + (".exe" * (os.name == "nt"))
+            build.mpy_cross(mpy_cross, version["tag"])
             zip_filename = os.path.join(output_directory,
                 filename_prefix + '-{TAG}-mpy-{VERSION}.zip'.format(
                     TAG=version["name"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 semver
 wheel
 tomli; python_version < "3.11"
+importlib_metadata; python_version < "3.8"


### PR DESCRIPTION
This is not formatted. I couldn't see anything about contributing guidelines other than code of conduct. Is black used for this project? It doesn't seem like it.

I did run this locally (on Windows with python v3.11.5) and everything seemed to work as expected. However, the newer `importlib_metadata.version()` returned a dev spec that wasn't PEP440 compatible; I'm not sure that really matters since I think only stable version specs are used for uploads to pypi.

tested with a single module package (circuitpython-cirque-pinnacle) and a multi-module package (circuitpython-nrf24l01)

### other chores
- removed an unused import
- updated actions/checkout to v4 in workflows
- updated actions/setup-python to v5 in workflows