### PR TITLE
ensure tags are present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         python3 --version
     - name: Checkout Current Repo
       uses: actions/checkout@v4
+      with:
+        filter: 'blob:none'
+        depth: 0
     - name: Install requirements
       run: |
         sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        filter: 'blob:none'
+        depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
this should fix the message during CI
```
.../setuptools_scm/git.py:163: UserWarning: "/home/runner/work/circuitpython-build-tools/circuitpython-build-tools" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
```

This may have been introduced when upgrading action/checkout recently, or it might be pre-existing.