### PR TITLE
Compress our zips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         python3 --version
     - name: Checkout Current Repo
       uses: actions/checkout@v4
+      with:
+        filter: 'blob:none'
+        depth: 0
     - name: Install requirements
       run: |
         sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        filter: 'blob:none'
+        depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/circuitpython_build_tools/scripts/build_bundles.py
+++ b/circuitpython_build_tools/scripts/build_bundles.py
@@ -205,7 +205,7 @@ def build_bundle(libs, bundle_version, output_filename, package_folder_prefix,
     print()
     print("Zipping")
 
-    with zipfile.ZipFile(output_filename, 'w') as bundle:
+    with zipfile.ZipFile(output_filename, 'w', compression=zipfile.ZIP_DEFLATED) as bundle:
         build_metadata = {"build-tools-version": build_tools_version}
         bundle.comment = json.dumps(build_metadata).encode("utf-8")
         if multiple_libs:


### PR DESCRIPTION
This saves ~50% on regular bundles and will save ~85% on the font bundle.

This also changes how the fetch is done (from shallow to blobless) so that we're sure to have tags. I noticed during builds in my branch that CI warned about missing tags.