### PR TITLE
Fix py build not using created temp file

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -311,7 +311,7 @@ def library(library_path, output_directory, package_folder_prefix,
                             if mpy_success != 0:
                                 raise RuntimeError("mpy-cross failed on", full_path)
                         else:
-                            shutil.copyfile(full_path, output_file)
+                            shutil.copyfile(temp_file_name, output_file)
                     finally:
                         os.remove(temp_file_name)
             else:


### PR DESCRIPTION
In the PR https://github.com/adafruit/circuitpython-build-tools/pull/101/files, the code in `build.library` was simplified, but in the case of the `py` file (not `mpy`) the original file was copied, not the temp file with the updated version