### PR TITLE
add skip_failed flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         # Use the community bundle because it's smaller and faster
         git clone --recurse-submodules https://github.com/adafruit/CircuitPython_Community_Bundle.git
         cd CircuitPython_Community_Bundle
-        circuitpython-build-bundles --filename_prefix test-bundle --library_location libraries --library_depth 2
+        circuitpython-build-bundles --filename_prefix test-bundle --library_location libraries --library_depth 2 --skip_failed
     - name: Build Python package
       run: |
         pip install --upgrade setuptools wheel twine readme_renderer testresources


### PR DESCRIPTION
Resolves: #120 

This adds a new `--skip_failed` flag to the CLI and relevant python functions, it defaults to `False` if unused so behavior stays the same as today. 

If the new flag is passed it will continue the build process instead of bailing after a failed build within a library. 

I will open a PR shortly in the community bundle that will utilize this flag to allow it build what it can even if some libraries do fail.

An open question that I'm interested in thoughts on is what to do in the case of the failed builds. It will still print the errors in the actions output, but with the Task passing it's unlikely to be seen there by anyone. I would guess without some other mechanism the most likely time it would be discovered is when someone tries to find that library within the bundle and is unable to.

Maybe a [notice message](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message) or [warning message](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message) 