### PR TITLE
Drop building 8.x bundles

### DIFF
--- a/circuitpython_build_tools/target_versions.py
+++ b/circuitpython_build_tools/target_versions.py
@@ -25,6 +25,5 @@
 # The tag specifies which version of CircuitPython to use for mpy-cross.
 # The name is used when constructing the zip file names.
 VERSIONS = [
-    {"tag": "8.2.0", "name": "8.x"},
-    {"tag": "9.0.0-alpha.2", "name": "9.x"},
+    {"tag": "9.2.4", "name": "9.x"},
 ]


### PR DESCRIPTION
As discussed in the weekly CircuitPython meeting, https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2025/2025-02-03.md#2643-in-the-weeds, we will drop building 8.x bundles. Also update to a newer version of `mpy-cross`.

- This is on the checklist here: https://github.com/adafruit/circuitpython/issues/9001