### PR TITLE
use python 3.12 inside actions containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
I think this may resolve the issue that a recent pypi email notice is warning about:
![image](https://github.com/user-attachments/assets/f4e2d1d7-508b-4e17-af8c-02fe95e84bd8)

I ran `python setup.py sdist` locallay and the resulting file does contain the underscored version of the name. I have python 3.12 locally on ubuntu-24.04 which I assume is what ubuntu-latest in this file points to, but haven't gone to check. 

I also tested inside of a python 3.10 container locally and confirmed in there it builds the hyphened version of the file that pypi is warning about. 