### PR TITLE
Fix markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ circuitpython-build-bundles --filename_prefix <output file prefix> --library_loc
 
 ## Contributing
 
-Contributions are welcome! Please read our [Code of Conduct](https://github.com/adafruit/Adafruit\_CircuitPython\_adabot/blob/master/CODE\_OF\_CONDUCT.md)
+Contributions are welcome! Please read our [Code of Conduct](https://github.com/adafruit/circuitpython-build-tools/blob/main/CODE_OF_CONDUCT.md)
 before contributing to help this project stay welcoming.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,5 @@ circuitpython-build-bundles --filename_prefix <output file prefix> --library_loc
 
 ## Contributing
 
-Contributions are welcome! Please read our [Code of Conduct]
-(https://github.com/adafruit/Adafruit\_CircuitPython\_adabot/blob/master/CODE\_OF\_CONDUCT.md)
+Contributions are welcome! Please read our [Code of Conduct](https://github.com/adafruit/Adafruit\_CircuitPython\_adabot/blob/master/CODE\_OF\_CONDUCT.md)
 before contributing to help this project stay welcoming.


### PR DESCRIPTION
Minor documentation fix to the Markdown in the README that broke the link to the Code of Conduct.  The second commit was me realizing the destination was out of date, so that has also been updated.