### PR TITLE
Allow for multiple package definitions in pyproject.toml

### DIFF
--- a/circuitpython_build_tools/build.py
+++ b/circuitpython_build_tools/build.py
@@ -258,7 +258,7 @@ def get_package_info(library_path, package_folder_prefix):
 
     if packages:
         if len(packages) > 1:
-            raise ValueError("Only a single package is supported")
+            print("Using first package defined in pyproject.toml as top-level package name")
         package_name = packages[0]
         # print(f"Using package name from pyproject.toml: {package_name}")
         package_info["is_package"] = True


### PR DESCRIPTION
A fix for issues such as https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad/issues/93, such that `pyproject.toml` allows for multiple packages to be defined.  This should allow for explicitly giving `setuptools` all the package names while also allowing the build tools to work the exact same way they currently do.